### PR TITLE
Settings: Add ongoing action chip toggle setting [2/2]

### DIFF
--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -341,4 +341,8 @@
     <string name="show_qs_on_secure_keyguard_title">Quick settings</string>
     <string name="show_qs_on_secure_keyguard_summary">Allow toggling quick settings on secure lockscreen</string>
 
+    <!-- Ongoing action chip -->
+    <string name="ongoing_action_chip_title">Ongoing action chip</string>
+    <string name="ongoing_action_chip_summary">Show progress indicator in status bar for ongoing actions like downloads</string> 
+
 </resources>

--- a/res/xml/configure_notification_settings.xml
+++ b/res/xml/configure_notification_settings.xml
@@ -204,5 +204,13 @@
             android:summary="@string/heads_up_summary"
             android:defaultValue="false" />
 
+        <!-- ongoing action -->
+         <SwitchPreferenceCompat
+            android:key="ongoing_action_chip"
+            android:order="27"
+            android:title="@string/ongoing_action_chip_title"
+            android:summary="@string/ongoing_action_chip_summary"
+            android:defaultValue="true" /> 
+
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
When disabled, the chip still appears. (need check)